### PR TITLE
Update Redis to Version 5.0.7

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -46,7 +46,7 @@ $(eval $(call addlib_s,libredis_client,$(CONFIG_LIBREDIS_CLIENT)))
 ################################################################################
 # Sources
 ################################################################################
-LIBREDIS_VERSION=5.0.6
+LIBREDIS_VERSION=5.0.7
 LIBREDIS_URL=https://github.com/antirez/redis/archive/$(LIBREDIS_VERSION).zip
 LIBREDIS_BASENAME=redis-$(LIBREDIS_VERSION)
 LIBREDIS_PATCHDIR=$(LIBREDIS_BASE)/patches


### PR DESCRIPTION
Changing the Redis version to `5.0.7` requires no further changes to the Unikraft library.

Signed-off-by: Fredrik Bakken <Fredrik.Bakken@gmail.com>