### PR TITLE
Update remote origin with official redis repository

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -47,7 +47,7 @@ $(eval $(call addlib_s,libredis_client,$(CONFIG_LIBREDIS_CLIENT)))
 # Sources
 ################################################################################
 LIBREDIS_VERSION=5.0.6
-LIBREDIS_URL=https://github.com/antirez/redis/archive/$(LIBREDIS_VERSION).zip
+LIBREDIS_URL=https://github.com/redis/redis/archive/$(LIBREDIS_VERSION).zip
 LIBREDIS_BASENAME=redis-$(LIBREDIS_VERSION)
 LIBREDIS_PATCHDIR=$(LIBREDIS_BASE)/patches
 $(eval $(call fetch,libredis,$(LIBREDIS_URL)))


### PR DESCRIPTION
In this commit, the remote origin is updated in accordance with the
official repository of Redis.

Signed-off-by: Gaulthier Gain <gaulthier.gain@uliege.be>