### PR TITLE
Remove mandatory dependency on ipv6 support

### DIFF
--- a/Config.uk
+++ b/Config.uk
@@ -19,7 +19,6 @@ config LIBREDIS_COMMON
 	select LIBPOSIX_SOCKET
 	select LIBPOSIX_EVENT
 	select LIBLWIP
-	select LWIP_IPV6
 # hidden
 config LIBREDIS_MAIN_FUNCTION
 	bool


### PR DESCRIPTION
Given the fact that `redis` works well without having the ipv6 support selected, this PR removes the mandatory dependency, enabling better testing with libraries that currently do not support ipv6 (eg. `musl`).

Signed-off-by: Maria Sfiraiala <maria.sfiraiala@gmail.com>