### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,6 @@
+name        := "redis"
+description := "An open source, in-memory data structure store, used as a database, cache, and message broker."
+gitrepo     := "https://github.com/redis/redis.git"
+homepage    := "https://redis.io"
+license     := "BSD-3-Clause"
+version     := 5.0.6 sha256:36c38ab5052facbbaac25bc823637d50b6b71926d1df123472903a818304e9ef https://github.com/redis/redis/archive/5.0.6.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

